### PR TITLE
Fix Wails config author field

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -3,7 +3,10 @@
   "name": "Truyenco",
   "shortname": "truyenco",
   "description": "Go backend and React frontend application",
-  "author": "",
+  "author": {
+    "name": "",
+    "email": ""
+  },
   "version": "0.0.1",
   "wailsVersion": "v2.9.1",
   "frontend": {


### PR DESCRIPTION
## Summary
- define `author` as object in wails config to match expected schema

## Testing
- `go test ./...` *(fails: command timed out pulling dependencies)*
- `wails dev` *(fails: command not found: wails)*

------
https://chatgpt.com/codex/tasks/task_e_68afeaabadf88330b2fc96da17b812e0